### PR TITLE
Perbaikan penutupan posisi & TP ganda berdasar kekuatan sinyal

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,6 +96,7 @@ Contoh key penting per simbol (disederhanakan):
 * **Exit**: `sl_mode` (ATR/PCT), `sl_pct`/`sl_atr_mult`, `sl_min_pct`, `sl_max_pct`,
   `use_breakeven`, `be_trigger_pct`, `trailing_trigger`, `trailing_step`,
   `max_hold_seconds`, `min_roi_to_close_by_time`, `time_stop_only_if_loss`
+* **TP**: `tp_mode`, blok `strength_rules`, `weak_tp_roi_pct`, `use_trailing_on_strong`
 * **Presisi/Lot**: `stepSize`, `minQty`, `quantityPrecision`, `minNotional`
 * **ML**: blok `ml` + `score_threshold` (atau ENV `SCORE_THRESHOLD`)
 
@@ -117,6 +118,7 @@ Contoh key penting per simbol (disederhanakan):
   * **Breakeven** (naikkan SL ke harga masuk bila profit ≥ trigger).
   * **Trailing** (di‑arm hanya jika profit > buffer aman **fee+slip**).
   * **Time‑stop** (tutup bila durasi > `max_hold_seconds` & ROI ≥ minimum; atau aturan *loss only*).
+  * **TP dua mode**: sinyal lemah → TP tetap, sinyal kuat → trailing + BE.
 * **Money Management**: risk % pada balance dan leverage; normalisasi qty ke **LOT\_SIZE**.
 
 ---

--- a/coin_config.json
+++ b/coin_config.json
@@ -39,6 +39,13 @@
       "down_prob_short": 0.45,
       "score_threshold": 1.0
     },
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.009,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
     "be_min_gap_pct": 0.0001,
@@ -99,6 +106,13 @@
       "down_prob_short": 0.45,
       "score_threshold": 1.2
     },
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.009,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
     "be_min_gap_pct": 0.0001,
@@ -133,9 +147,9 @@
     "taker_fee": 0.0005,
     "margin_type": "ISOLATED",
     "startup_skip_bars": 0,
-    "min_atr_pct": 0.0024,
-    "max_atr_pct": 0.04,
-    "max_body_atr": 1.75,
+    "min_atr_pct": 0.0020,
+    "max_atr_pct": 0.05,
+    "max_body_atr": 2.0,
     "use_htf_filter": 0,
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
@@ -154,11 +168,16 @@
       ]
     },
     "ml": {
-      "strict": true,
-      "up_prob_long": 0.55,
-      "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "strict": false,
+      "score_threshold": 0.90
     },
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.01,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
     "be_min_gap_pct": 0.0001,


### PR DESCRIPTION
## Ringkasan
- Gunakan `closePosition` pada STOP/TP untuk menghindari sisa posisi serta verifikasi market close dengan retry dan sapu debu
- Tambah mode TP ganda: sinyal lemah TP 10% ROI, sinyal kuat pakai trailing
- Posisi hanya di-set setelah entry sukses dan konfigurasi XRP dilonggarkan + kunci `tp_mode`

## Testing
- `python tools_dryrun_summary.py --symbol XRPUSDT --csv XRP_15m.csv --coin_config coin_config.json --steps 1500 --balance 20` *(gagal: index out of bounds)*


------
https://chatgpt.com/codex/tasks/task_e_68ab0d2939488328b0ce8f7e9bbec37c