### PR TITLE
Perbaikan format qty dan konfigurasi XRP

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -147,9 +147,9 @@
     "taker_fee": 0.0005,
     "margin_type": "ISOLATED",
     "startup_skip_bars": 0,
-    "min_atr_pct": 0.0020,
+    "min_atr_pct": 0.0015,
     "max_atr_pct": 0.05,
-    "max_body_atr": 2.0,
+    "max_body_atr": 2.2,
     "use_htf_filter": 0,
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
@@ -169,13 +169,10 @@
     },
     "ml": {
       "strict": false,
-      "score_threshold": 0.90
+      "score_threshold": 0.85
     },
     "tp_mode": "dual_strength",
-    "strength_rules": {
-      "weak_if_atr_pct_lt": 0.01,
-      "weak_if_roi_future_lt": 0.15
-    },
+    "strength_rules": { "weak_if_atr_pct_lt": 0.008, "weak_if_roi_future_lt": 0.15 },
     "weak_tp_roi_pct": 0.10,
     "use_trailing_on_strong": 1,
     "use_breakeven": 1,


### PR DESCRIPTION
## Ringkasan
- tambah helper `_qty_to_str` untuk format qty sesuai presisi exchange
- kirim quantity sebagai string pada entry/close/stop dan dukung `close_all`
- longgarkan filter volatilitas dan ML untuk XRP agar sinyal lebih sering

## Pengujian
- `python -m py_compile newrealtrading.py`
- `python -m json.tool coin_config.json >/dev/null`
- `python - <<'PY'
from newrealtrading import ExecutionClient
ex=ExecutionClient.__new__(ExecutionClient)
ex.symbol_filters={'XRPUSDT':{'stepSize':'0.1','quantityPrecision':1}}
print(ex._qty_to_str('XRPUSDT',8.7))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ab9b39f27083288084cdfba8bffa9f