### PR TITLE
Perbaikan presisi order dan config

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -20,10 +20,10 @@
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
     "sl_pct": 0.008,
-    "sl_atr_mult": 1.8,
-    "sl_min_pct": 0.012,
-    "sl_max_pct": 0.035,
-    "be_trigger_r": 0.0,
+    "sl_atr_mult": 1.6,
+    "sl_min_pct": 0.010,
+    "sl_max_pct": 0.030,
+    "be_trigger_r": 0.5,
     "trail": {
       "use_adx_step": false,
       "min_step_pct": 0.006,
@@ -34,16 +34,30 @@
       ]
     },
     "ml": {
-      "strict": true,
-      "up_prob_long": 0.55,
-      "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "strict": false,
+      "score_threshold": 1.2
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
-    "be_min_gap_pct": 0.0001,
+    "be_min_gap_pct": 0.001,
     "trailing_trigger": 1.0,
     "trailing_step": 0.3,
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.01,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
+    "adopt_manual_positions": 1,
+    "manual_guard": {
+      "place_sl_on_attach": 1,
+      "sl_on_attach_mode": "ATR",
+      "sl_on_attach_atr_mult": 1.6,
+      "sl_on_attach_pct": 0.012,
+      "sl_min_pct": 0.010,
+      "sl_max_pct": 0.030
+    },
     "trail_atr_k": 2.0,
     "early_stop_enabled": 0,
     "early_stop_bars": 2,
@@ -80,10 +94,10 @@
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
     "sl_pct": 0.008,
-    "sl_atr_mult": 1.8,
-    "sl_min_pct": 0.012,
-    "sl_max_pct": 0.035,
-    "be_trigger_r": 0.0,
+    "sl_atr_mult": 1.6,
+    "sl_min_pct": 0.010,
+    "sl_max_pct": 0.030,
+    "be_trigger_r": 0.5,
     "trail": {
       "use_adx_step": false,
       "min_step_pct": 0.006,
@@ -94,16 +108,30 @@
       ]
     },
     "ml": {
-      "strict": true,
-      "up_prob_long": 0.55,
-      "down_prob_short": 0.45,
+      "strict": false,
       "score_threshold": 1.2
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
-    "be_min_gap_pct": 0.0001,
+    "be_min_gap_pct": 0.001,
     "trailing_trigger": 1.0,
     "trailing_step": 0.3,
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.01,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
+    "adopt_manual_positions": 1,
+    "manual_guard": {
+      "place_sl_on_attach": 1,
+      "sl_on_attach_mode": "ATR",
+      "sl_on_attach_atr_mult": 1.6,
+      "sl_on_attach_pct": 0.012,
+      "sl_min_pct": 0.010,
+      "sl_max_pct": 0.030
+    },
     "trail_atr_k": 2.0,
     "early_stop_enabled": 0,
     "early_stop_bars": 2,
@@ -140,10 +168,10 @@
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
     "sl_pct": 0.008,
-    "sl_atr_mult": 1.8,
-    "sl_min_pct": 0.012,
-    "sl_max_pct": 0.035,
-    "be_trigger_r": 0.0,
+    "sl_atr_mult": 1.6,
+    "sl_min_pct": 0.010,
+    "sl_max_pct": 0.030,
+    "be_trigger_r": 0.5,
     "trail": {
       "use_adx_step": false,
       "min_step_pct": 0.006,
@@ -154,16 +182,30 @@
       ]
     },
     "ml": {
-      "strict": true,
-      "up_prob_long": 0.55,
-      "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "strict": false,
+      "score_threshold": 1.2
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
-    "be_min_gap_pct": 0.0001,
+    "be_min_gap_pct": 0.001,
     "trailing_trigger": 1.0,
     "trailing_step": 0.3,
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.01,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
+    "adopt_manual_positions": 1,
+    "manual_guard": {
+      "place_sl_on_attach": 1,
+      "sl_on_attach_mode": "ATR",
+      "sl_on_attach_atr_mult": 1.6,
+      "sl_on_attach_pct": 0.012,
+      "sl_min_pct": 0.010,
+      "sl_max_pct": 0.030
+    },
     "trail_atr_k": 2.0,
     "early_stop_enabled": 0,
     "early_stop_bars": 2,
@@ -200,10 +242,10 @@
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
     "sl_pct": 0.008,
-    "sl_atr_mult": 1.8,
-    "sl_min_pct": 0.012,
-    "sl_max_pct": 0.035,
-    "be_trigger_r": 0.0,
+    "sl_atr_mult": 1.6,
+    "sl_min_pct": 0.010,
+    "sl_max_pct": 0.030,
+    "be_trigger_r": 0.5,
     "trail": {
       "use_adx_step": false,
       "min_step_pct": 0.006,
@@ -214,16 +256,30 @@
       ]
     },
     "ml": {
-      "strict": true,
-      "up_prob_long": 0.55,
-      "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "strict": false,
+      "score_threshold": 1.2
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
-    "be_min_gap_pct": 0.0001,
+    "be_min_gap_pct": 0.001,
     "trailing_trigger": 1.0,
     "trailing_step": 0.3,
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.01,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
+    "adopt_manual_positions": 1,
+    "manual_guard": {
+      "place_sl_on_attach": 1,
+      "sl_on_attach_mode": "ATR",
+      "sl_on_attach_atr_mult": 1.6,
+      "sl_on_attach_pct": 0.012,
+      "sl_min_pct": 0.010,
+      "sl_max_pct": 0.030
+    },
     "trail_atr_k": 2.0,
     "early_stop_enabled": 0,
     "early_stop_bars": 2,
@@ -260,10 +316,10 @@
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
     "sl_pct": 0.008,
-    "sl_atr_mult": 1.8,
-    "sl_min_pct": 0.012,
-    "sl_max_pct": 0.035,
-    "be_trigger_r": 0.0,
+    "sl_atr_mult": 1.6,
+    "sl_min_pct": 0.010,
+    "sl_max_pct": 0.030,
+    "be_trigger_r": 0.5,
     "trail": {
       "use_adx_step": false,
       "min_step_pct": 0.006,
@@ -274,16 +330,30 @@
       ]
     },
     "ml": {
-      "strict": true,
-      "up_prob_long": 0.55,
-      "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "strict": false,
+      "score_threshold": 1.2
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
-    "be_min_gap_pct": 0.0001,
+    "be_min_gap_pct": 0.001,
     "trailing_trigger": 1.0,
     "trailing_step": 0.3,
+    "tp_mode": "dual_strength",
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.01,
+      "weak_if_roi_future_lt": 0.15
+    },
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
+    "adopt_manual_positions": 1,
+    "manual_guard": {
+      "place_sl_on_attach": 1,
+      "sl_on_attach_mode": "ATR",
+      "sl_on_attach_atr_mult": 1.6,
+      "sl_on_attach_pct": 0.012,
+      "sl_min_pct": 0.010,
+      "sl_max_pct": 0.030
+    },
     "trail_atr_k": 2.0,
     "early_stop_enabled": 0,
     "early_stop_bars": 2,

--- a/engine_core.py
+++ b/engine_core.py
@@ -232,16 +232,17 @@ def make_decision(df: pd.DataFrame, symbol: str, coin_cfg: dict, ml_up_prob: flo
         if short_base and ml_up_prob <= params["down_prob"]:
             score_short += params["weight"]
     thr = params["score_threshold"]
-    if params["strict"] and ml_up_prob is None:
+    if params.get("enabled", True) and params.get("strict", False) and ml_up_prob is None:
         logging.getLogger(__name__).info(f"[{symbol}] ML_WARMUP: menunda hingga model siap (strict).")
         return None
+    logging.getLogger(__name__).info(f"[{symbol}] ML use={params['enabled']} up_prob={ml_up_prob}")
     decision = None
     if score_long >= thr and score_long > score_short:
         decision = "LONG"
     elif score_short >= thr and score_short > score_long:
         decision = "SHORT"
     logging.getLogger(__name__).info(
-        f"[{symbol}] DECISION base(L={long_base},S={short_base}) up_prob={ml_up_prob} thr={thr} score(L={score_long:.2f},S={score_short:.2f}) -> {decision}"
+        f"[{symbol}] decision={decision} (long_base={long_base}, short_base={short_base})"
     )
     return decision
 


### PR DESCRIPTION
## Ringkasan
- Tambah helper `price_to_str` dan `qty` string presisi untuk pemesanan
- Perbaiki stop/close dengan `closePosition` dan sapu sisa posisi
- Sesuaikan konfigurasi koin dan gating ML

## Pengujian
- `python -m py_compile newrealtrading.py engine_core.py`
- `python -m json.tool coin_config.json`


------
https://chatgpt.com/codex/tasks/task_e_68abd2735a7c83289f6df54b2073288b