### PR TITLE
Perbaikan sanitasi order dan TP/SL protektif

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -307,6 +307,14 @@
       "sl_on_attach_atr_mult": 1.6,
       "sl_on_attach_mode": "ATR",
       "sl_on_attach_pct": 0.012
+    },
+    "tp_mode": "dual_strength",
+    "weak_tp_roi_pct": 0.10,
+    "use_trailing_on_strong": 1,
+    "use_trailing_on_weak": 0,
+    "strength_rules": {
+      "weak_if_atr_pct_lt": 0.01,
+      "weak_if_roi_future_lt": 0.15
     }
   },
   "TURBOUSDT": {


### PR DESCRIPTION
## Ringkasan
- Sanitasi parameter order agar reduceOnly/quantity sesuai aturan Binance
- Tambah helper order untuk SL/TP close-all dan market close reduce-only
- Logika entry pasang SL protektif dan TP weak 10% tanpa trailing

## Pengujian
- `python -m py_compile newrealtrading.py`
- `python -m json.tool coin_config.json >/tmp/coin_config_checked.json`


------
https://chatgpt.com/codex/tasks/task_e_68abd98843748328bafc4c9bd49da443