### PR TITLE
Perbaiki cast float, side, dan retry order

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -1,4 +1,10 @@
 {
+  "_defaults": {
+    "weak_tp_roi_pct": 0.10,
+    "weak_spot_up_pct": 0.01,
+    "weak_fut_up_roi": 0.15,
+    "use_trailing_when_strong": true
+  },
   "ADAUSDT": {
     "SLIPPAGE_PCT": 0.02,
     "adopt_manual_positions": 1,


### PR DESCRIPTION
## Ringkasan
- Gunakan `_to_float` untuk semua nilai float dari sumber eksternal agar aman dari `None`
- Pastikan argumen `side` bertipe `str` dengan `assert` dan `cast`
- Satukan definisi `_order_with_retry` dengan dukungan retry kuantitas dan harga
- Tambah `_defaults` pada `coin_config.json` untuk konfigurasi weak/strong TP

## Pengujian
- `python -m py_compile newrealtrading.py`
- `python -m json.tool coin_config.json`

------
https://chatgpt.com/codex/tasks/task_e_68abe142ddcc8328b792d72244acb100