### PR TITLE
Rapikan bool dan guard backtester scalping

### DIFF
--- a/tests/test_backtester_types.py
+++ b/tests/test_backtester_types.py
@@ -1,0 +1,80 @@
+import ast
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from typing import Tuple
+from ta.momentum import RSIIndicator
+
+
+def _load_function(name: str):
+    source = Path('backtester_scalping.py').read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            mod = ast.Module([node], type_ignores=[])
+            code = compile(mod, filename='tmp', mode='exec')
+            env = {'np': np, 'pd': pd, 'RSIIndicator': RSIIndicator, 'Tuple': Tuple}
+            exec(code, env)
+            return env[name]
+    raise RuntimeError(f'Function {name} not found')
+
+
+def test_near_level_returns_bool():
+    near_level = _load_function('near_level')
+    out = near_level(1.0, np.array([0.99, 1.01]), 2.0)
+    assert isinstance(out, bool)
+
+
+def test_ltf_momentum_ok_tuple():
+    ltf_momentum_ok = _load_function('ltf_momentum_ok')
+    df = pd.DataFrame({'close': [1, 1.01, 1.02, 1.03, 1.04, 1.05]})
+    out = ltf_momentum_ok(df)
+    assert isinstance(out[0], bool) and isinstance(out[1], bool)
+
+
+def _extract_breakeven_block():
+    source = Path('backtester_scalping.py').read_text()
+    tree = ast.parse(source)
+    parent = {child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == 'apply_breakeven_sl':
+            cur = parent.get(node)
+            while cur and not (isinstance(cur, ast.If) and 'position_type is not None' in ast.unparse(cur.test)):
+                cur = parent.get(cur)
+            if cur:
+                first = cur.body[0] if cur.body else None
+                if isinstance(first, ast.If):
+                    new_if = ast.If(test=cur.test, body=[first], orelse=[])
+                    mod = ast.Module([new_if], type_ignores=[])
+                    ast.fix_missing_locations(mod)
+                    return compile(mod, filename='tmp', mode='exec')
+    raise RuntimeError('breakeven block not found')
+
+
+def test_breakeven_guard():
+    code = _extract_breakeven_block()
+
+    def run(pos):
+        called = {'flag': False}
+
+        def fake_apply_breakeven_sl(**kwargs):
+            called['flag'] = True
+            return kwargs['sl']
+
+        env = {
+            'apply_breakeven_sl': fake_apply_breakeven_sl,
+            'in_position': True,
+            'position_type': pos,
+            'entry': 1.0,
+            'qty': 1.0,
+            'sl': 0.9,
+            'price': 1.0,
+            'use_breakeven': True,
+            'sym_cfg': {},
+            'be_trigger_pct': 0.0,
+        }
+        exec(code, env)
+        return called['flag']
+
+    assert run(None) is False
+    assert run('LONG') is True


### PR DESCRIPTION
## Ringkasan
- Pastikan near_level dan ltf_momentum_ok mengembalikan bool murni
- Tambahkan anotasi tipe state, termasuk cooldown dan posisi
- Lindungi pemanggilan apply_breakeven_sl dengan pengecekan position_type

## Pengujian
- `pytest tests/test_backtester_types.py -q`
- `timeout 5s streamlit run backtester_scalping.py --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68ad3621a51483288f7dc41bc96a2e26