### PR TITLE
normalize rule resample jam untuk hilangkan warning pandas

### DIFF
--- a/backtester_scalping.py
+++ b/backtester_scalping.py
@@ -344,9 +344,9 @@ if selected_file:
             if short_raw and near_level(px, SUP, sr_near_pct):
                 short_raw = False; blocked_reasons_short.append('near_support')
         if use_mtf_plus:
-            if long_raw and not htf_trend_ok_multi('LONG', df.iloc[:i+1], rules=('1H','4H')):
+            if long_raw and not htf_trend_ok_multi('LONG', df.iloc[:i+1], rules=('1h','4h')):
                 long_raw = False; blocked_reasons_long.append('htf_trend_mismatch')
-            if short_raw and not htf_trend_ok_multi('SHORT', df.iloc[:i+1], rules=('1H','4H')):
+            if short_raw and not htf_trend_ok_multi('SHORT', df.iloc[:i+1], rules=('1h','4h')):
                 short_raw = False; blocked_reasons_short.append('htf_trend_mismatch')
             l_ok, s_ok = ltf_momentum_ok(df.iloc[:i+1], lookback=5, rsi_thr_long=52, rsi_thr_short=48)
             if long_raw and not l_ok:

--- a/tests/test_sr_utils.py
+++ b/tests/test_sr_utils.py
@@ -2,7 +2,7 @@ import sys, os
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import numpy as np
 import pandas as pd
-from indicators.sr_utils import compute_sr_levels, near_level, build_sr_cache, ltf_momentum_ok, htf_trend_ok_multi
+from indicators.sr_utils import compute_sr_levels, near_level, build_sr_cache, ltf_momentum_ok, htf_trend_ok_multi, _resample_close
 
 def _mkdf(n=350):
     idx = pd.date_range("2024-01-01", periods=n, freq="15min")
@@ -28,4 +28,10 @@ def test_ltf_momentum_and_htf_return_bool():
     df = _mkdf(500)
     l_ok, s_ok = ltf_momentum_ok(df, lookback=5)
     assert isinstance(l_ok, bool) and isinstance(s_ok, bool)
-    assert isinstance(htf_trend_ok_multi("LONG", df, rules=("1H","4H")), bool)
+    assert isinstance(htf_trend_ok_multi("LONG", df, rules=("1h","4h")), bool)
+
+def test_resample_close_normalizes_rule():
+    df = _mkdf(200)
+    a = _resample_close(df, "1H")
+    b = _resample_close(df, "1h")
+    assert len(a) == len(b)


### PR DESCRIPTION
## Ringkasan
- normalisasi alias jam kapital agar selalu memakai huruf kecil sebelum dipakai pandas
- ubah default HTF rules ke ('1h','4h') dan perbarui panggilan backtester
- tambah uji _resample_close memastikan '1H' dan '1h' konsisten

## Pengujian
- `python - <<'PY' ...` (tidak ada FutureWarning)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad477c40208328a1a4b2c28564034d