### PR TITLE
Tambah ringkasan param aktif dan ekspor coin_config

### DIFF
--- a/optimizer/exporter.py
+++ b/optimizer/exporter.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import json, os
+from typing import Dict, Any
+
+SAFE_STRATEGY_KEY = "strategy_scalping"
+
+# peta param strategi -> kunci coin_config (legacy) yang aman di-overwrite
+LEGACY_MAP = {
+    "be_trigger_pct": "be_trigger_pct",
+    "trailing_step": "trailing_step",
+    "trailing_trigger": "trailing_trigger",
+    "use_breakeven": "use_breakeven",
+    "slippage_pct": "SLIPPAGE_PCT",
+    # tambahkan map lain bila dibutuhkan
+}
+
+def export_params_to_coin_config(
+    coin_config_path: str,
+    symbol: str,
+    params: Dict[str, Any],
+    also_update_legacy: bool = True
+) -> Dict[str, Any]:
+    """
+    Simpan param aktif ke coin_config.json tanpa merusak struktur lama.
+    - Menyimpan snapshot lengkap param strategi ke <symbol>["strategy_scalping"]
+    - (opsional) Mengisi beberapa kunci legacy yang umum dipakai runner realtrade
+    Return: dict coin_config terbaru (yang sudah disimpan ke file).
+    """
+    if not os.path.exists(coin_config_path):
+        raise FileNotFoundError(f"coin_config.json tidak ditemukan: {coin_config_path}")
+    with open(coin_config_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    if symbol not in cfg:
+        # jika simbol belum ada, tiru SYMBOL_DEFAULTS kemudian tempelkan
+        base = cfg.get("SYMBOL_DEFAULTS", {}).copy()
+        cfg[symbol] = base
+    # simpan snapshot strategi di namespace aman
+    sym = cfg[symbol]
+    sym[SAFE_STRATEGY_KEY] = dict(params)  # shallow copy cukup
+    # opsional: isi beberapa kunci legacy agar runner lama tetap sinkron
+    if also_update_legacy:
+        # normalisasi beberapa nama
+        if "SLIPPAGE_PCT" not in params and "slippage_pct" in params:
+            params["SLIPPAGE_PCT"] = params["slippage_pct"]
+        for k_src, k_dst in LEGACY_MAP.items():
+            if k_src in params and params[k_src] is not None:
+                sym[k_dst] = params[k_src]
+    # tulis balik ke file
+    with open(coin_config_path, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2, ensure_ascii=False)
+    return cfg

--- a/tests/test_param_overrides.py
+++ b/tests/test_param_overrides.py
@@ -1,0 +1,40 @@
+import json, os, tempfile, shutil
+from optimizer.param_loader import load_params_from_csv
+from optimizer.exporter import export_params_to_coin_config, SAFE_STRATEGY_KEY
+
+def _mk_coin_config(tmpdir: str) -> str:
+    p = os.path.join(tmpdir, "coin_config.json")
+    cfg = {
+        "_defaults": {},
+        "SYMBOL_DEFAULTS": {"use_breakeven": 1, "SLIPPAGE_PCT": 0.02},
+        "ADAUSDT": {"use_breakeven": 1, "SLIPPAGE_PCT": 0.02}
+    }
+    with open(p, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    return p
+
+def test_export_params_to_coin_config_basic():
+    tmp = tempfile.mkdtemp()
+    try:
+        path = _mk_coin_config(tmp)
+        params = {
+            "ema_len": 34, "sma_len": 20, "rsi_period": 25,
+            "min_atr_pct": 0.006, "max_atr_pct": 0.03,
+            "score_threshold": 1.2, "use_sr_filter": True, "sr_near_pct": 0.8,
+            "use_mtf_plus": True,
+            "be_trigger_pct": 0.45,
+            "trailing_trigger": 0.7, "trailing_step": 0.45,
+            "slippage_pct": 0.02,
+        }
+        cfg = export_params_to_coin_config(path, "ADAUSDT", params, also_update_legacy=True)
+        assert "ADAUSDT" in cfg
+        assert SAFE_STRATEGY_KEY in cfg["ADAUSDT"]
+        snap = cfg["ADAUSDT"][SAFE_STRATEGY_KEY]
+        assert snap["ema_len"] == 34 and snap["sma_len"] == 20
+        # legacy keys updated
+        assert cfg["ADAUSDT"]["be_trigger_pct"] == 0.45
+        assert cfg["ADAUSDT"]["trailing_step"] == 0.45
+        assert cfg["ADAUSDT"]["trailing_trigger"] == 0.7
+        assert cfg["ADAUSDT"]["SLIPPAGE_PCT"] == 0.02
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)


### PR DESCRIPTION
## Ringkasan
- tambah modul `exporter` untuk menyimpan parameter strategi ke `coin_config.json` secara aman
- tampilkan panel ringkasan parameter aktif serta tombol apply ke `coin_config.json` di backtester scalping
- tambahkan unit test untuk memastikan override parameter tersimpan benar

## Pengujian
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad65aedd5c8328ac5a23946c563a45