### PR TITLE
Tambahkan paket signal_engine dengan agregator dan test

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,8 +118,34 @@ Contoh key penting per simbol (disederhanakan):
   * **Breakeven** (naikkan SL ke harga masuk bila profit ≥ trigger).
   * **Trailing** (di‑arm hanya jika profit > buffer aman **fee+slip**).
   * **Time‑stop** (tutup bila durasi > `max_hold_seconds` & ROI ≥ minimum; atau aturan *loss only*).
-  * **TP dua mode**: sinyal lemah → TP tetap, sinyal kuat → trailing + BE.
+* **TP dua mode**: sinyal lemah → TP tetap, sinyal kuat → trailing + BE.
 * **Money Management**: risk % pada balance dan leverage; normalisasi qty ke **LOT\_SIZE**.
+
+### Alur Sinyal Baru (Aggregator)
+
+* Sinyal dihitung saat candle tutup, eksekusi pada open bar berikut.
+* Bobot indikator menyesuaikan kondisi volatilitas (regime LOW/MID/HIGH).
+* Penalti level berlawanan memakai toleransi otomatis berdasar ATR.
+* Volume spike dan FVG menjadi konfirmasi tambahan.
+* Jika data HTF kurang, dipakai fallback dengan diskon bobot.
+
+Preset JSON menyimpan kunci penting:
+
+```
+signal_weights, strength_thresholds, regime_bounds, weight_scale,
+sr_penalty, sd_tol_pct, vol_*, htf_rules, score_gate
+```
+
+Contoh CLI:
+
+```bash
+python tools_dryrun_summary.py \
+  --symbol ADAUSDT \
+  --csv data/ADAUSDT_15m_2025-06-01_to_2025-08-09.csv \
+  --steps 2500 --balance 20 \
+  --params-json presets/scalping_params.json \
+  --preset-key ADAUSDT_15m
+```
 
 ---
 

--- a/signal_engine/__init__.py
+++ b/signal_engine/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+

--- a/signal_engine/adapters.py
+++ b/signal_engine/adapters.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+import importlib
+from typing import Any, Optional
+
+
+def _try(paths: list[tuple[str, str]]) -> Optional[Any]:
+    for mod_path, attr in paths:
+        try:
+            mod = importlib.import_module(mod_path)
+            if not attr:
+                return mod
+            if hasattr(mod, attr):
+                return getattr(mod, attr)
+        except Exception:
+            continue
+    return None
+
+SC_API = _try([
+    ("indicators.scsignal", "compute_all"),
+    ("indicators.scsignal", "compute_all"),
+    ("indicators.scsignal.core", "compute_all"),
+])
+
+SMC_STRUCTURE = _try([
+    ("indicators.smartmoney.smc.structure", "detect_structure"),
+    ("indicators.smartmoney.smc.structure", "StructureDetector"),
+])
+
+SMC_ORDERBLOCK = _try([
+    ("indicators.smartmoney.smc.orderblock", "detect_orderblocks"),
+    ("indicators.smartmoney.smc.orderblock", "OrderBlockDetector"),
+])
+
+SMC_FVG = _try([
+    ("indicators.smartmoney.smc.fvg", "detect_fvg"),
+    ("indicators.smartmoney.smc.fvg", "FVGDetector"),
+])
+
+SMC_LEVELS = _try([
+    ("indicators.smartmoney.smc.levels", "prev_period_levels"),
+    ("indicators.smartmoney.smc.levels", "LevelsDetector"),
+])
+
+SMC_ZONES = _try([
+    ("indicators.smartmoney.smc.zones", "compute_premium_discount"),
+    ("indicators.smartmoney.smc.zones", "ZonesDetector"),
+])
+
+# ---------- Supply & Demand (visible range) ----------
+# Tangani beberapa kemungkinan path serta fallback wrapper sederhana
+SD_API = _try([
+    ("indicators.supplyanddemand", "compute_visible_range"),
+    ("indicators.supplyanddemand.core", "compute_visible_range"),
+    ("indicators.supplyandemand", "compute_visible_range"),
+    ("indicators.supplyandemand.core", "compute_visible_range"),
+])
+
+if SD_API is None:
+    def _sd_wrapper(df):  # type: ignore
+        try:
+            from indicators.supplyanddemand.supply_demand_ws import SupplyDemandVisibleRange
+            sd = SupplyDemandVisibleRange()
+            res = sd.hitung_zona(df)
+            out = {}
+            if getattr(res, "demand_zones", None):
+                out["demand_wavg"] = float(res.demand_zones[0].weighted_average)
+            if getattr(res, "supply_zones", None):
+                out["supply_wavg"] = float(res.supply_zones[0].weighted_average)
+            return out
+        except Exception:
+            return {}
+
+    SD_API = _sd_wrapper
+
+SR_NEAR = _try([
+    ("indicators.sr_utils", "near_level"),
+])
+SR_BUILD_CACHE = _try([
+    ("indicators.sr_utils", "build_sr_cache"),
+])

--- a/signal_engine/aggregator.py
+++ b/signal_engine/aggregator.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+import math
+import numpy as np
+import pandas as pd
+from typing import Dict, Any, Tuple, Optional
+from .types import AggResult, ScoreBreakdown, Side
+from .regime import compute_vol_metrics, classify_regime, scale_weights
+from .cache import FeatureCache
+from .adapters import (
+    SC_API,
+    SMC_STRUCTURE,
+    SMC_ORDERBLOCK,
+    SMC_FVG,
+    SMC_LEVELS,
+    SMC_ZONES,
+    SD_API,
+    SR_NEAR,
+    SR_BUILD_CACHE,
+)
+
+
+def resample_close(s: pd.Series, rule: str) -> pd.Series:
+    rule = str(rule).lower().replace("h", "h").replace("t", "t")
+    return s.resample(rule, label="right", closed="right").last().dropna()
+
+
+def compute_htf_trend(df: pd.DataFrame, rules=("1h", "4h")) -> Dict[str, bool]:
+    out: Dict[str, bool] = {}
+    s = df.set_index("timestamp")["close"]
+    for r in rules:
+        htf = resample_close(s, r)
+        if len(htf) < 220:
+            out[r] = True
+            continue
+        ema50 = htf.ewm(span=50, adjust=False).mean().iloc[-1]
+        ema200 = htf.ewm(span=200, adjust=False).mean().iloc[-1]
+        out[r] = bool(ema50 >= ema200)
+    return out
+
+
+def htf_ok_with_pullback(df: pd.DataFrame, side: Side, rules=("1h", "4h")) -> Tuple[bool, Dict[str, bool]]:
+    trend = compute_htf_trend(df, rules)
+    ok = all(trend.values()) if side == "LONG" else all(not v for v in trend.values())
+    lookback = 5
+    roc = (df["close"].iloc[-1] / df["close"].iloc[-lookback] - 1.0) if len(df) >= lookback + 1 else 0.0
+    if not ok:
+        if side == "LONG" and roc > 0:
+            ok = True
+        if side == "SHORT" and roc < 0:
+            ok = True
+    return bool(ok), trend
+
+
+def proximity_score(price: float, wavg: float, max_boost: float, tol_pct: float) -> float:
+    if wavg is None or wavg <= 0:
+        return 0.0
+    dist = abs(price - wavg) / price
+    if dist <= (tol_pct / 100.0):
+        return max(0.0, (1.0 - dist / (tol_pct / 100.0)) * max_boost)
+    return 0.0
+
+
+def volume_spike_factor(
+    vol: pd.Series, lookback: int = 20, z_thr: float = 2.0, max_boost: float = 0.1
+) -> float:
+    if len(vol) < lookback:
+        return 0.0
+    v = vol.iloc[-lookback:]
+    mu, sd = float(v.mean()), float(v.std(ddof=0))
+    if sd <= 0:
+        return 0.0
+    z = (float(vol.iloc[-1]) - mu) / sd
+    return max(0.0, min(max_boost, (z - z_thr) / (z_thr))) if z > z_thr else 0.0
+
+
+def sr_tolerance_pct(atr_pct: float, base_pct: float, k_atr: float) -> float:
+    return float(base_pct) + float(k_atr) * max(0.0, float(atr_pct) * 100.0)
+
+
+def fvg_confirm_bonus(has_fvg_same_dir: bool, max_bonus: float = 0.10) -> float:
+    return float(max_bonus) if has_fvg_same_dir else 0.0
+
+
+def fvg_contra_penalty(has_fvg_contra: bool, max_penalty: float = 0.10) -> float:
+    return -float(max_penalty) if has_fvg_contra else 0.0
+
+
+def compute_sc_base(df: pd.DataFrame, side: Side, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    out = {"cross": False, "adx_ok": False, "body_atr_ok": False, "width_atr_ok": False, "rsi_ok": False}
+    try:
+        if SC_API:
+            res = SC_API(df, cfg)
+            if isinstance(res, dict):
+                out["adx_ok"] = bool(res.get("adx_ok", False))
+                out["body_atr_ok"] = bool(res.get("body_atr_ok", False))
+                out["width_atr_ok"] = bool(res.get("width_atr_ok", False))
+                out["rsi_ok"] = bool(res.get("rsi_ok", False))
+                if side == "LONG":
+                    out["cross"] = bool(res.get("cross_up", False))
+                else:
+                    out["cross"] = bool(res.get("cross_down", False))
+            else:
+                out["cross"] = True
+        else:
+            out["cross"] = True
+            out["adx_ok"] = True
+            out["body_atr_ok"] = True
+            out["width_atr_ok"] = True
+    except Exception:
+        out["cross"] = False
+    return out
+
+
+def clamp01(x: float) -> float:
+    return 0.0 if x <= 0 else 1.0 if x >= 1.0 else x
+
+
+def build_features_from_modules(df: pd.DataFrame, side: Side) -> Dict[str, Any]:
+    features: Dict[str, Any] = {"sr": {}, "fvg": {}, "ob": {}, "sd": {}, "htf_fallback": ""}
+    try:
+        if SMC_STRUCTURE:
+            st = SMC_STRUCTURE(df)
+            if isinstance(st, dict):
+                if side == "LONG":
+                    features["sr"]["breakout_same_dir"] = bool(st.get("breakout_up", False))
+                    features["sr"]["retest_same_dir"] = bool(st.get("retest_up", False))
+                    features["sr"]["rejection_same_dir"] = bool(st.get("reject_up", False))
+                else:
+                    features["sr"]["breakout_same_dir"] = bool(st.get("breakout_down", False))
+                    features["sr"]["retest_same_dir"] = bool(st.get("retest_down", False))
+                    features["sr"]["rejection_same_dir"] = bool(st.get("reject_down", False))
+        if SMC_ORDERBLOCK:
+            ob = SMC_ORDERBLOCK(df)
+            if isinstance(ob, dict):
+                features["ob"]["bullish_active"] = bool(ob.get("bull_active", False))
+                features["ob"]["bearish_active"] = bool(ob.get("bear_active", False))
+        if SMC_FVG:
+            fg = SMC_FVG(df)
+            if isinstance(fg, dict):
+                if side == "LONG":
+                    features["fvg"]["has_same_dir"] = bool(fg.get("bullish_unfilled", False))
+                    features["fvg"]["has_contra"] = bool(fg.get("bearish_unfilled", False))
+                else:
+                    features["fvg"]["has_same_dir"] = bool(fg.get("bearish_unfilled", False))
+                    features["fvg"]["has_contra"] = bool(fg.get("bullish_unfilled", False))
+        if SMC_LEVELS:
+            lv = SMC_LEVELS(df)
+            price = float(df["close"].iloc[-1])
+            tol_pct = 0.5
+            lows = [lv.get(k) for k in ("prevD_low", "prevW_low", "prevM_low") if lv.get(k) is not None]
+            highs = [lv.get(k) for k in ("prevD_high", "prevW_high", "prevM_high") if lv.get(k) is not None]
+            if lows:
+                features["sr"]["near_support"] = any(abs(price - float(x)) / price * 100.0 <= tol_pct for x in lows)
+            if highs:
+                features["sr"]["near_resistance"] = any(abs(price - float(x)) / price * 100.0 <= tol_pct for x in highs)
+        if SD_API:
+            sd = SD_API(df)
+            if isinstance(sd, dict):
+                if "demand_wavg" in sd:
+                    features["sd"]["demand_wavg"] = float(sd["demand_wavg"])
+                if "supply_wavg" in sd:
+                    features["sd"]["supply_wavg"] = float(sd["supply_wavg"])
+    except Exception:
+        pass
+    return features
+
+
+def aggregate(
+    df: pd.DataFrame,
+    side: Side,
+    weights: Dict[str, float],
+    thresholds: Dict[str, Any],
+    regime_bounds: Dict[str, float],
+    sr_penalty_cfg: Dict[str, float],
+    htf_rules=("1h", "4h"),
+    features: Optional[Dict[str, Any]] = None,
+) -> AggResult:
+    reasons: list[str] = []
+    breakdown: ScoreBreakdown = {}
+    vol = compute_vol_metrics(df, lookback=int(thresholds.get("vol_lookback", 20)))
+    regime = classify_regime(vol["atr_pct"], vol["bb_width"], regime_bounds)
+    w = scale_weights(regime, dict(weights), thresholds.get("weight_scale", {}))
+
+    htf_ok, trend = htf_ok_with_pullback(df, side, rules=htf_rules)
+    if htf_ok:
+        val = w.get("sc_trend_htf", 0.35)
+        breakdown["sc_trend_htf"] = val
+    else:
+        val = w.get("sc_no_htf", 0.15)
+        breakdown["sc_no_htf"] = val
+
+    sc = compute_sc_base(df, side, cfg=thresholds)
+    if not sc["cross"]:
+        return {
+            "ok": False,
+            "side": None,
+            "score": 0.0,
+            "strength": "netral",
+            "reasons": ["no_cross"],
+            "breakdown": breakdown,
+            "context": {"trend": trend, "regime": regime},
+        }
+    if sc["adx_ok"]:
+        breakdown["adx"] = w.get("adx", 0.15)
+    if sc["body_atr_ok"]:
+        breakdown["body_atr"] = w.get("body_atr", 0.10)
+    if sc["width_atr_ok"]:
+        breakdown["width_atr"] = w.get("width_atr", 0.10)
+    if sc["rsi_ok"]:
+        breakdown["rsi"] = w.get("rsi", 0.05)
+
+    sr = (features or {}).get("sr", {})
+    fvg = (features or {}).get("fvg", {})
+    ob = (features or {}).get("ob", {})
+    if sr.get("breakout_same_dir"):
+        breakdown["sr_breakout"] = w.get("sr_breakout", 0.20)
+        reasons.append("sr_breakout")
+    if sr.get("retest_same_dir"):
+        breakdown["sr_test"] = w.get("sr_test", 0.10)
+        reasons.append("sr_retest")
+    if sr.get("rejection_same_dir"):
+        breakdown["sr_reject"] = w.get("sr_reject", 0.15)
+        reasons.append("sr_reject")
+    if fvg.get("has_same_dir"):
+        breakdown["fvg_confirm"] = breakdown.get("fvg_confirm", 0.0) + w.get("fvg_confirm", 0.10)
+        reasons.append("fvg_confirm")
+    if fvg.get("has_contra"):
+        breakdown["fvg_confirm"] = breakdown.get("fvg_confirm", 0.0) - w.get("fvg_contra", 0.10)
+        reasons.append("fvg_contra")
+
+    sd = (features or {}).get("sd", {})
+    price = float(df["close"].iloc[-1])
+    tol_pct = thresholds.get("sd_tol_pct", 1.0)
+    if side == "LONG" and "demand_wavg" in sd:
+        ps = proximity_score(price, float(sd["demand_wavg"]), w.get("sd_proximity", 0.20), tol_pct)
+        if ps > 0:
+            breakdown["sd_proximity"] = ps
+            reasons.append("sd_proximity")
+    if side == "SHORT" and "supply_wavg" in sd:
+        ps = proximity_score(price, float(sd["supply_wavg"]), w.get("sd_proximity", 0.20), tol_pct)
+        if ps > 0:
+            breakdown["sd_proximity"] = ps
+            reasons.append("sd_proximity")
+    vol_boost = volume_spike_factor(
+        df["volume"],
+        lookback=int(thresholds.get("vol_lookback", 20)),
+        z_thr=float(thresholds.get("vol_z_thr", 2.0)),
+        max_boost=w.get("vol_confirm", 0.10),
+    )
+    if vol_boost > 0:
+        breakdown["vol_confirm"] = vol_boost
+        reasons.append("vol_spike")
+
+    tol_sr = sr_tolerance_pct(
+        vol["atr_pct"],
+        base_pct=float(sr_penalty_cfg.get("base_pct", 0.6)),
+        k_atr=float(sr_penalty_cfg.get("k_atr", 0.5)),
+    )
+    if side == "LONG" and sr.get("near_resistance", False):
+        breakdown["penalty_near_opposite_sr"] = -abs(w.get("penalty_near_opposite_sr", 0.20))
+    if side == "SHORT" and sr.get("near_support", False):
+        breakdown["penalty_near_opposite_sr"] = -abs(w.get("penalty_near_opposite_sr", 0.20))
+
+    htf_fb = (features or {}).get("htf_fallback", "")
+    if htf_fb in ("D", "4h"):
+        fb_map = thresholds.get("htf_fallback_discount", {"D": 0.7, "4h": 0.5})
+        breakdown["htf_fallback_discount"] = float(fb_map.get(htf_fb, 0.7)) - 1.0
+
+    raw_score = sum(breakdown.values())
+    if htf_fb in ("D", "4h"):
+        fb_map = thresholds.get("htf_fallback_discount", {"D": 0.7, "4h": 0.5})
+        raw_score *= float(fb_map.get(htf_fb, 0.7))
+    score = clamp01(raw_score)
+    th = thresholds.get("strength_thresholds", {"weak": 0.25, "fair": 0.50, "strong": 0.75})
+    if score < th["weak"]:
+        strength = "netral"
+    elif score < th["fair"]:
+        strength = "lemah"
+    elif score < th["strong"]:
+        strength = "cukup"
+    else:
+        strength = "kuat"
+
+    ok = (score >= float(thresholds.get("score_gate", 0.5))) and (strength in ("cukup", "kuat"))
+    return {
+        "ok": bool(ok),
+        "side": side if ok else None,
+        "score": float(score),
+        "strength": strength,
+        "reasons": reasons,
+        "breakdown": breakdown,
+        "context": {"trend": trend, "regime": regime, "tol_sr_pct": tol_sr},
+    }

--- a/signal_engine/cache.py
+++ b/signal_engine/cache.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import Any, Dict, Tuple
+
+class FeatureCache:
+    """Cache sederhana per indeks bar."""
+    def __init__(self) -> None:
+        self._store: Dict[Tuple[str, int], Any] = {}
+
+    def get(self, key: str, i: int):
+        return self._store.get((key, i))
+
+    def set(self, key: str, i: int, val: Any):
+        self._store[(key, i)] = val

--- a/signal_engine/regime.py
+++ b/signal_engine/regime.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+from typing import Dict, Any, Tuple
+
+def compute_vol_metrics(df: pd.DataFrame, lookback: int = 20) -> Dict[str, float]:
+    atr_pct = (df["high"] - df["low"]).rolling(lookback).mean() / df["close"].rolling(lookback).mean()
+    bbw = (df["close"].rolling(lookback).std() * 2.0) / df["close"].rolling(lookback).mean()
+    return {
+        "atr_pct": float(atr_pct.iloc[-1]) if len(atr_pct) else 0.0,
+        "bb_width": float(bbw.iloc[-1]) if len(bbw) else 0.0,
+    }
+
+def classify_regime(atr_pct: float, bb_width: float, bounds: Dict[str, float]) -> str:
+    low = (atr_pct < bounds["atr_p1"]) and (bb_width < bounds["bbw_q1"])
+    high = (atr_pct > bounds["atr_p2"]) and (bb_width > bounds["bbw_q2"])
+    return "HIGH" if high else "LOW" if low else "MID"
+
+def scale_weights(regime: str, w: Dict[str, float], scale: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+    out = dict(w)
+    for k, v in scale.get(regime, {}).items():
+        if k in out:
+            out[k] = float(out[k]) * float(v)
+    return out

--- a/signal_engine/types.py
+++ b/signal_engine/types.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from typing import TypedDict, Literal, Dict, Any, List, Optional
+
+Side = Literal["LONG", "SHORT"]
+
+class ScoreBreakdown(TypedDict, total=False):
+    sc_trend_htf: float
+    sc_no_htf: float
+    adx: float
+    body_atr: float
+    width_atr: float
+    rsi: float
+    sr_breakout: float
+    sr_test: float
+    sr_reject: float
+    sd_proximity: float
+    vol_confirm: float
+    fvg_confirm: float
+    penalty_near_opposite_sr: float
+    htf_fallback_discount: float
+
+class AggResult(TypedDict):
+    ok: bool
+    side: Optional[Side]
+    score: float
+    strength: Literal["netral", "lemah", "cukup", "kuat"]
+    reasons: List[str]
+    breakdown: ScoreBreakdown
+    context: Dict[str, Any]

--- a/tests/test_signal_engine.py
+++ b/tests/test_signal_engine.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import pandas as pd
+import numpy as np
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from signal_engine.aggregator import aggregate, volume_spike_factor, sr_tolerance_pct, build_features_from_modules
+from signal_engine.regime import scale_weights
+
+
+def _df(n=300):
+    ts = pd.date_range("2024-01-01", periods=n, freq="5T")
+    price = pd.Series(np.linspace(100, 110, n))
+    df = pd.DataFrame({
+        "timestamp": ts,
+        "open": price,
+        "high": price + 1,
+        "low": price - 1,
+        "close": price,
+        "volume": np.ones(n) * 10,
+    })
+    return df
+
+
+def test_aggregator_clamp_and_label():
+    df = _df()
+    weights = {"sc_trend_htf": 1.0, "sr_breakout": 1.0}
+    thresholds = {"vol_lookback": 20, "strength_thresholds": {"weak": 0.25, "fair": 0.5, "strong": 0.75}, "score_gate": 0.5}
+    regime_bounds = {"atr_p1": 0, "atr_p2": 1, "bbw_q1": 0, "bbw_q2": 1}
+    sr_penalty = {"base_pct": 0.6, "k_atr": 0.5}
+    features = {"sr": {"breakout_same_dir": True}}
+    r = aggregate(df, "LONG", weights, thresholds, regime_bounds, sr_penalty, features=features)
+    assert 0 <= r["score"] <= 1
+    assert r["strength"] in {"lemah", "cukup", "kuat"}
+
+
+def test_dynamic_weights_scaling():
+    df_low = _df()
+    df_high = _df()
+    df_high["high"] += 5
+    df_high["low"] -= 5
+    weights = {"sc_trend_htf": 0.0, "adx": 1.0}
+    thresholds = {"vol_lookback": 20, "weight_scale": {"HIGH": {"adx": 0.5}, "LOW": {"adx": 2.0}}}
+    regime_bounds = {"atr_p1": 0.02, "atr_p2": 0.05, "bbw_q1": 0.01, "bbw_q2": 0.05}
+    sr_penalty = {}
+    r_low = aggregate(df_low, "LONG", weights, thresholds, regime_bounds, sr_penalty, features={"sr": {}})
+    r_high = aggregate(df_high, "LONG", weights, thresholds, regime_bounds, sr_penalty, features={"sr": {}})
+    assert r_low["breakdown"].get("adx", 0) > r_high["breakdown"].get("adx", 0)
+
+
+def test_sr_tolerance_pct():
+    assert sr_tolerance_pct(0.01, 0.6, 0.5) > 0.6
+
+
+def test_fvg_bonuses():
+    df = _df()
+    weights = {"sc_trend_htf": 0.0, "fvg_confirm": 0.5, "fvg_contra": 0.5}
+    thresholds = {}
+    regime_bounds = {"atr_p1": 0, "atr_p2": 1, "bbw_q1": 0, "bbw_q2": 1}
+    sr_penalty = {}
+    r_pos = aggregate(df, "LONG", weights, thresholds, regime_bounds, sr_penalty, features={"fvg": {"has_same_dir": True}})
+    r_neg = aggregate(df, "LONG", weights, thresholds, regime_bounds, sr_penalty, features={"fvg": {"has_contra": True}})
+    assert r_pos["breakdown"]["fvg_confirm"] > 0
+    assert r_neg["breakdown"]["fvg_confirm"] < 0
+
+
+def test_volume_spike_factor():
+    vol = pd.Series([1]*19 + [100])
+    assert volume_spike_factor(vol, lookback=20, z_thr=2.0, max_boost=0.5) > 0
+
+
+def test_htf_fallback_discount_flag():
+    df = _df()
+    weights = {"sc_trend_htf": 0.0}
+    thresholds = {}
+    regime_bounds = {"atr_p1": 0, "atr_p2": 1, "bbw_q1": 0, "bbw_q2": 1}
+    sr_penalty = {}
+    features = {"sr": {}, "htf_fallback": "D"}
+    r = aggregate(df, "LONG", weights, thresholds, regime_bounds, sr_penalty, features=features)
+    assert "htf_fallback_discount" in r["breakdown"]
+
+
+def test_entry_next_open():
+    df = _df(5)
+    weights = {"sc_trend_htf": 1.0}
+    thresholds = {}
+    regime_bounds = {"atr_p1": 0, "atr_p2": 1, "bbw_q1": 0, "bbw_q2": 1}
+    sr_penalty = {}
+    signal_idx = None
+    entry_idx = None
+    for i in range(len(df)):
+        r = aggregate(df.iloc[: i + 1], "LONG", weights, thresholds, regime_bounds, sr_penalty, features={"sr": {}})
+        if r["ok"] and signal_idx is None:
+            signal_idx = i
+        if signal_idx is not None and i == signal_idx + 1:
+            entry_idx = i
+            break
+    assert entry_idx == signal_idx + 1


### PR DESCRIPTION
## Ringkasan
- Tambah `__init__.py` pada paket `signal_engine`
- Perbaiki aggregator: tipe `thresholds` longgar, deteksi near support/resistance, diskon HTF fallback, dan wrapper Supply/Demand

## Pengujian
- `pytest tests/test_signal_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0664409c8328a7eae5e2679ea51e