### PR TITLE
Normalisasi seri numerik dan boolean pada SCSignals

### DIFF
--- a/tests/test_scsignals_series_dtype.py
+++ b/tests/test_scsignals_series_dtype.py
@@ -18,5 +18,5 @@ def test_numeric_series_outputs():
     out = mod.compute_all(df, {})
     for k, v in out.items():
         if hasattr(v, "dtype"):
-            assert str(v.dtype).startswith(("float", "int"))
+            assert str(v.dtype).startswith(("float", "int", "bool"))
 


### PR DESCRIPTION
## Ringkasan
- Normalisasi ATR, Donchian, dan indikator lain sebagai float64 sebelum perbandingan.
- Ganti operator `~use_*` dengan kondisi per-simbol yang eksplisit.
- `buy_raw`/`sell_raw` kini berupa seri boolean dan tes diperbarui.

## Pengujian
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae924cba8c832888f03ff7472bd084