### PR TITLE
Integrasi layanan Support/Resistance MTF ke engine dan agregator

### DIFF
--- a/aggregators/__init__.py
+++ b/aggregators/__init__.py
@@ -1,0 +1,1 @@
+# Paket agregator fitur S/R

--- a/aggregators/sr_features.py
+++ b/aggregators/sr_features.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+from typing import Dict, List, Tuple
+import math
+import pandas as pd
+from indicators.srmtf.support_resistance_mtf import Zone, Signal
+
+def _atr_last(chart_df: pd.DataFrame, length: int = 17) -> float:
+    high, low, close = chart_df["high"], chart_df["low"], chart_df["close"]
+    prev = close.shift(1)
+    tr = pd.concat([(high - low), (high - prev).abs(), (low - prev).abs()], axis=1).max(axis=1)
+    return float(tr.rolling(length, min_periods=1).mean().iloc[-1])
+
+def _nearest_zone_distance(price: float, zones: List[Zone]) -> Tuple[str, float]:
+    """
+    Kembalikan (kind, distance_abs) terhadap tepi zona terdekat (bukan center).
+    kind: 'R'|'S' atau '' bila tak ada zona.
+    """
+    best = ("", math.inf)
+    for z in zones:
+        # distance ke tepi terdekat
+        if price > z.top:
+            d = price - z.top
+        elif price < z.bottom:
+            d = z.bottom - price
+        else:
+            d = 0.0
+        if d < best[1]:
+            best = (z.kind, d)
+    return best
+
+def sr_features_from_signals(chart_df: pd.DataFrame,
+                             signals_by_group: Dict[str, List[Signal]],
+                             zones_by_group: Dict[str, List[Zone]],
+                             cfg: dict) -> Dict[str, float]:
+    """
+    Ubah sinyal S/R ke fitur numerik (0..1) dan boolean (0/1) untuk aggregator.
+    Aturan mengikuti alur: konfirmasi di close, skor di-clamp [0,1], penalti jarak/ATR.
+    """
+    features: Dict[str, float] = {}
+    if not signals_by_group:
+        return features
+
+    last_close = float(chart_df["close"].iloc[-1])
+    atr = _atr_last(chart_df, length=int(cfg.get("atr_len", 17)))
+    near_mult = float(cfg.get("near_zone_atr_mult", 0.8))  # threshold “near” (× ATR)
+
+    # Features “near zone” berdasar semua zona gabungan
+    all_zones: List[Zone] = []
+    for zs in zones_by_group.values():
+        all_zones.extend(zs)
+    kind_near, dist = _nearest_zone_distance(last_close, all_zones) if all_zones else ("", math.inf)
+    features["sr_near_support"] = 1.0 if (kind_near == "S" and dist <= near_mult * atr) else 0.0
+    features["sr_near_resistance"] = 1.0 if (kind_near == "R" and dist <= near_mult * atr) else 0.0
+
+    # Sinyal khusus (breakout/test/retest/rejection) → 1.0 pada bar ini
+    kinds = {"BULL_BREAKOUT": "sr_breakout_bull",
+             "BEAR_BREAKOUT": "sr_breakout_bear",
+             "TEST_R": "sr_test_r", "TEST_S": "sr_test_s",
+             "RETEST_R": "sr_retest_r", "RETEST_S": "sr_retest_s",
+             "REJECT_UP": "sr_reject_up", "REJECT_DOWN": "sr_reject_down"}
+
+    for g, sigs in signals_by_group.items():
+        for s in sigs:
+            name = kinds.get(s.kind)
+            if not name:
+                continue
+            # optional distance penalty (lebih jauh dari zona → lebih lemah)
+            # d=0 pada breakout sebenarnya, TEST/RETEST/REJECT diberi sedikit penalti
+            if s.ref_zone.kind == "R":
+                dist_edge = max(0.0, last_close - s.ref_zone.bottom) if s.kind in ("TEST_R","RETEST_R","REJECT_UP") else 0.0
+            else:
+                dist_edge = max(0.0, s.ref_zone.top - last_close) if s.kind in ("TEST_S","RETEST_S","REJECT_DOWN") else 0.0
+            penalty = 1.0 - min(1.0, dist_edge / (atr if atr > 0 else 1.0))
+            val = max(0.0, min(1.0, penalty))
+            features[name] = max(features.get(name, 0.0), val)
+
+    return features
+
+def sr_reason_weights_default() -> Dict[str, float]:
+    """Default bobot agar aggregator bisa langsung dipakai kalau belum ada di config."""
+    return {
+        "sr_breakout_bull": 0.35,
+        "sr_breakout_bear": 0.35,
+        "sr_test_r": 0.15,
+        "sr_test_s": 0.15,
+        "sr_retest_r": 0.20,
+        "sr_retest_s": 0.20,
+        "sr_reject_up": 0.25,
+        "sr_reject_down": 0.25,
+        "sr_near_support": 0.10,
+        "sr_near_resistance": 0.10,
+    }

--- a/coin_config.json
+++ b/coin_config.json
@@ -79,7 +79,35 @@
     "use_breakeven": 1,
     "use_htf_filter": 0,
     "use_trailing_on_strong": 1,
-    "weak_tp_roi_pct": 0.1
+    "weak_tp_roi_pct": 0.1,
+    "sr_mtf": {
+      "enabled": true,
+      "chart_tf": "15m",
+      "use_presets": false,
+      "detection_tfs": ["1h","4h"],
+      "detection_length": 15,
+      "sr_margin": 2.0,
+      "filter_false_breakouts": true,
+      "use_prev_historical_levels": true,
+      "atr_len": 17,
+      "vol_sma_len": 17,
+      "rejection_shadow_mult": 1.618,
+      "rejection_vol_mult": 1.618,
+      "false_breakout_atr_mult": 0.5,
+      "near_zone_atr_mult": 0.8,
+      "reason_weights": {
+        "sr_breakout_bull": 0.35,
+        "sr_breakout_bear": 0.35,
+        "sr_test_r": 0.15,
+        "sr_test_s": 0.15,
+        "sr_retest_r": 0.20,
+        "sr_retest_s": 0.20,
+        "sr_reject_up": 0.25,
+        "sr_reject_down": 0.25,
+        "sr_near_support": 0.10,
+        "sr_near_resistance": 0.10
+      }
+    }
   },
   "ALGOUSDT": {
     "SLIPPAGE_PCT": 0.02,

--- a/indicators/srmtf/sr_service.py
+++ b/indicators/srmtf/sr_service.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Iterable, Tuple
+import pandas as pd
+from .support_resistance_mtf import SupportResistanceMTF, Zone, Signal, resample_ohlcv
+
+@dataclass
+class SRServiceConfig:
+    enabled: bool = True
+    chart_tf: str = "15m"
+    use_presets: bool = True                 # INTRADAY(1m/5m/15m) & HTF(1h/4h)
+    detection_tfs: Optional[Iterable[str]] = None  # contoh: ["4h"]
+    detection_length: int = 15
+    sr_margin: float = 2.0
+    filter_false_breakouts: bool = True
+    use_prev_historical_levels: bool = True
+    atr_len: int = 17
+    vol_sma_len: int = 17
+    rejection_shadow_mult: float = 1.618
+    rejection_vol_mult: float = 1.618
+    false_breakout_atr_mult: float = 0.5
+
+class SRMTFService:
+    """
+    Layanan S/R MTF berulir:
+    - bootstrap() sekali di awal (dari base_1m atau data_by_tf)
+    - on_bar_close(chart_df) setiap bar close → emisi sinyal untuk bar terakhir
+    - simpan levels_by_group untuk dipakai fitur "near zone"
+    """
+    def __init__(self, cfg: SRServiceConfig):
+        self.cfg = cfg
+        self.srm = SupportResistanceMTF(
+            detection_length=cfg.detection_length,
+            sr_margin=cfg.sr_margin,
+            filter_false_breakouts=cfg.filter_false_breakouts,
+            use_prev_historical_levels=cfg.use_prev_historical_levels,
+            atr_len=cfg.atr_len,
+            vol_sma_len=cfg.vol_sma_len,
+            rejection_shadow_mult=cfg.rejection_shadow_mult,
+            rejection_vol_mult=cfg.rejection_vol_mult,
+            false_breakout_atr_mult=cfg.false_breakout_atr_mult,
+        )
+        self.levels_by_group: Dict[str, List[Zone]] = {}
+        self._last_ts: Optional[pd.Timestamp] = None
+
+    @staticmethod
+    def from_coin_cfg(coin_cfg: dict) -> "SRMTFService":
+        sr = coin_cfg.get("sr_mtf", {})
+        cfg = SRServiceConfig(
+            enabled=sr.get("enabled", True),
+            chart_tf=sr.get("chart_tf", "15m"),
+            use_presets=sr.get("use_presets", True),
+            detection_tfs=sr.get("detection_tfs"),
+            detection_length=int(sr.get("detection_length", 15)),
+            sr_margin=float(sr.get("sr_margin", 2.0)),
+            filter_false_breakouts=bool(sr.get("filter_false_breakouts", True)),
+            use_prev_historical_levels=bool(sr.get("use_prev_historical_levels", True)),
+            atr_len=int(sr.get("atr_len", 17)),
+            vol_sma_len=int(sr.get("vol_sma_len", 17)),
+            rejection_shadow_mult=float(sr.get("rejection_shadow_mult", 1.618)),
+            rejection_vol_mult=float(sr.get("rejection_vol_mult", 1.618)),
+            false_breakout_atr_mult=float(sr.get("false_breakout_atr_mult", 0.5)),
+        )
+        return SRMTFService(cfg)
+
+    def bootstrap(self, *, chart_df: pd.DataFrame, base_1m: Optional[pd.DataFrame]=None,
+                  data_by_tf: Optional[Dict[str, pd.DataFrame]]=None) -> None:
+        """Hitung level awal sesuai konfigurasi (sekali di start atau saat reload data)."""
+        if not self.cfg.enabled:
+            self.levels_by_group = {}
+            return
+        levels, _ = self.srm.compute(
+            chart_df=chart_df,
+            chart_tf=self.cfg.chart_tf,
+            base_1m=base_1m,
+            data_by_tf=data_by_tf,
+            detection_tfs=self.cfg.detection_tfs,
+            use_presets=self.cfg.use_presets,
+            include_sentiment_profile=True,
+        )
+        self.levels_by_group = levels
+        self._last_ts = None
+
+    def on_bar_close(self, chart_df: pd.DataFrame) -> Dict[str, List[Signal]]:
+        """
+        Panggil pada setiap bar close dari TF chart.
+        Return: sinyal hanya untuk bar terakhir (per group).
+        """
+        if not self.cfg.enabled or not self.levels_by_group:
+            return {}
+        # Deteksi sinyal dari group level yang ada, hanya ambil bar terakhir
+        ts_last = chart_df.index[-1]
+        signals_by_group: Dict[str, List[Signal]] = {}
+        for g, zones in self.levels_by_group.items():
+            sigs = self.srm.detect_signals(chart_df, self.cfg.chart_tf, zones)
+            sigs_last = [s for s in sigs if s.ts == ts_last]
+            if sigs_last:
+                signals_by_group[g] = sigs_last
+        self._last_ts = ts_last
+        return signals_by_group
+
+    def zones(self) -> Dict[str, List[Zone]]:
+        return self.levels_by_group

--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -645,6 +645,7 @@ class CoinTrader:
         self.rehydrate_profit_min_pct = float(_to_float(self.config.get('rehydrate_profit_min_pct', 0.0005), 0.0005))
         self.signal_confirm_bars_after_restart = int(self.config.get('signal_confirm_bars_after_restart', 2))
         self.signal_flip_confirm_left = 0
+        self.last_sr_reasons: List[dict] = []
 
     def _log(self, msg: str) -> None:
         if getattr(self, 'verbose', False):
@@ -1185,7 +1186,10 @@ class CoinTrader:
             else:
                 long_base, short_base = compute_base_signals_live(df)
             self._log(f"[{self.symbol}] ML use={self.ml.use_ml} up_prob={up_prob}")
-            decision = make_decision(df, self.symbol, self.config, up_prob)
+            decision, sr_reasons = make_decision(df, self.symbol, self.config, up_prob)
+            self.last_sr_reasons = sr_reasons
+            if os.getenv("DEBUG_REASONS") == "1" and sr_reasons:
+                print(f"[{self.symbol}] reasons: {sr_reasons}")
             self._log(f"[{self.symbol}] decision={decision} (long_base={long_base}, short_base={short_base})")
             long_sig = decision == 'LONG'
             short_sig = decision == 'SHORT'

--- a/tests/test_sr_features.py
+++ b/tests/test_sr_features.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pandas as pd
+from indicators.srmtf.support_resistance_mtf import Zone, Signal
+from aggregators.sr_features import sr_features_from_signals, sr_reason_weights_default
+
+def _make_chart(n=120, seed=7):
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2025-08-10", periods=n, freq="15min")
+    base = np.cumsum(rng.normal(0, 0.2, size=n)) + 10.0
+    df = pd.DataFrame({
+        "open": base,
+        "high": base + rng.random(n) * 0.2,
+        "low":  base - rng.random(n) * 0.2,
+        "close": base,
+        "volume": rng.integers(100, 2000, size=n),
+    }, index=idx)
+    return df
+
+def test_features_mapping_basic():
+    chart = _make_chart()
+    ts = chart.index[-1]
+    last = float(chart["close"].iloc[-1])
+    z = Zone(kind="R", top=last*1.005, bottom=last*0.999, level=last, tf="4h",
+             created_at=ts, margin_factor=0.1)
+    s = Signal(ts=ts, tf_chart="15m", kind="REJECT_UP", price=last, ref_zone=z, volume=500, volume_sma=200, atr=0.1)
+    feats = sr_features_from_signals(chart, {"HTF":[s]}, {"HTF":[z]}, {"atr_len":17, "near_zone_atr_mult": 10.0})
+    assert feats.get("sr_reject_up", 0.0) > 0.0
+    assert feats.get("sr_near_resistance", 0.0) >= 0.0
+    weights = sr_reason_weights_default()
+    assert "sr_reject_up" in weights


### PR DESCRIPTION
## Ringkasan
- Tambah `SRMTFService` beserta konfigurasi untuk mengelola level dan sinyal S/R multi‑timeframe
- Sediakan mapper `sr_features_from_signals` agar sinyal S/R berubah menjadi fitur numerik & alasan terponderasi
- Integrasi layanan dan fitur S/R ke proses pengambilan keputusan serta konfigurasi per‑koin

## Pengujian
- `pytest -q tests/test_srmtf.py`
- `pytest -q tests/test_sr_features.py`
- `DEBUG_REASONS=1 python tools_dryrun_summary.py --symbol ADAUSDT --csv data/ADAUSDT_15m_2025-08-01_to_2025-08-19.csv --coin_config coin_config.json --steps 1200 --balance 20` *(gagal: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb81ac6a08328a56e2c55023659cc