### PR TITLE
Perbaiki path modul supply and demand

### DIFF
--- a/signal_engine/adapters.py
+++ b/signal_engine/adapters.py
@@ -50,8 +50,6 @@ SMC_ZONES = _try([
 SD_API = _try([
     ("indicators.supplyanddemand", "compute_visible_range"),
     ("indicators.supplyanddemand.core", "compute_visible_range"),
-    ("indicators.supplyandemand", "compute_visible_range"),
-    ("indicators.supplyandemand.core", "compute_visible_range"),
 ])
 
 if SD_API is None:


### PR DESCRIPTION
## Ringkasan
- Perbaiki daftar import Supply & Demand agar hanya memakai modul `supplyanddemand` yang benar.

## Pengujian
- `pytest`
- `python - <<'PY'\nfrom signal_engine.adapters import SD_API\nprint(SD_API)\nprint(getattr(SD_API, '__module__', 'tanpa modul'))\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68b032d079b48328b52417c68305e1f4